### PR TITLE
Fix typo in tutorials

### DIFF
--- a/docs/source/tutorials/01_quickstart.rst
+++ b/docs/source/tutorials/01_quickstart.rst
@@ -16,7 +16,7 @@ First, let's load the robot.
     robot = pk.Robot.from_urdf(urdf)
 
 
-Now, let's solve the IK problem using the :func:`solve_ik` snippit available in :mod:`pyroki_snippets`.
+Now, let's solve the IK problem using the :func:`solve_ik` snippet available in :mod:`pyroki_snippets`.
 
 .. code-block:: python
 

--- a/docs/source/tutorials/02_more_ik_problems.rst
+++ b/docs/source/tutorials/02_more_ik_problems.rst
@@ -8,7 +8,7 @@ This section expands on the :doc:`basic IK example <01_quickstart>` by extending
 3. Incorporating collision avoidance costs.
 4. Optimizing for robot end-effector manipulability.
 
-All the examples below are available as snippits in :mod:`pyroki_snippets`, and interactive demos are located in the ``examples/`` directory.
+All the examples below are available as snippets in :mod:`pyroki_snippets`, and interactive demos are located in the ``examples/`` directory.
 
 
 ==========================================


### PR DESCRIPTION
## Summary
- fix 'snippit' typos in docs

## Testing
- `ruff check docs/ src/ examples/`
- `ruff format docs/ src/ examples/ --check`
- `pyright .` *(fails: missing imports and other issues)*
- `pytest -q` *(fails: command not found)*