### PR TITLE
Add custom URDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ git clone https://github.com/chungmin99/pyroki.git
 cd pyroki
 pip install -e .
 ```
+## Custom URDFs
+Place URDF files that you want to experiment with inside the `urdf/` directory located at the project root.
+You can load them with `pyroki.load_custom_urdf` and then create a `Robot` instance:
 
+```python
+import pyroki as pk
+
+urdf = pk.load_custom_urdf("my_robot.urdf")
+robot = pk.Robot.from_urdf(urdf)
+```
 
 ## Status
 

--- a/src/pyroki/__init__.py
+++ b/src/pyroki/__init__.py
@@ -4,3 +4,4 @@ from . import viewer as viewer
 from ._robot import Robot as Robot
 
 __version__ = "0.0.0"
+from .loaders import load_custom_urdf as load_custom_urdf

--- a/src/pyroki/loaders.py
+++ b/src/pyroki/loaders.py
@@ -1,0 +1,23 @@
+import pathlib
+import yourdfpy
+
+URDF_DIR = pathlib.Path(__file__).resolve().parents[2] / "urdf"
+
+
+def load_custom_urdf(filename: str) -> yourdfpy.URDF:
+    """Load a URDF file from the project's ``urdf`` directory.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the URDF file relative to the ``urdf`` directory.
+
+    Returns
+    -------
+    yourdfpy.URDF
+        Parsed URDF object.
+    """
+    path = URDF_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(f"URDF file '{filename}' not found in {URDF_DIR}.")
+    return yourdfpy.URDF.load(str(path))


### PR DESCRIPTION
## Summary
- add loader for URDF files placed in a new `urdf/` directory
- export the loader in the package
- document how to load custom URDFs in the README
- include empty `.gitkeep` so the directory is tracked

## Testing
- `ruff check src/pyroki/loaders.py src/pyroki/__init__.py`
- `pyright src/pyroki/loaders.py src/pyroki/__init__.py` *(fails: Import "yourdfpy" could not be resolved)*
- `pytest -q` *(fails: command not found)*